### PR TITLE
Fix bug: Set version of newly allocated slot to 1 instead of 0

### DIFF
--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -28,6 +28,8 @@ pub struct LvmtStore<'cache, 'db> {
     auth_changes: KeyValueStoreBulks<'db, AuthChangeTable>,
 }
 
+const ALLOC_START_VERSION: u64 = 1;
+
 impl<'cache, 'db> LvmtStore<'cache, 'db> {
     fn commit(
         &self,
@@ -52,7 +54,7 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
             } else {
                 let allocation = allocate_version_slot(&key, &slot_alloc_view)?;
                 allocations.push(AllocationKeyInfo::new(allocation.slot_index, key.clone()));
-                (allocation, 0)
+                (allocation, ALLOC_START_VERSION)
             };
 
             amt_change_manager.record_with_allocation(allocation, &key);


### PR DESCRIPTION
This PR addresses a bug where the version of the newly allocated slot was incorrectly set to 0. Since unallocated slots are calculated with a version of 0, the initial allocation should set the version to 1 at the time of allocation to maintain consistency. To enhance clarity, a new constant `ALLOC_START_VERSION` is introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/15)
<!-- Reviewable:end -->
