### PR TITLE
Fix a logic bug in slot allocation within `LvmtStore`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,9 @@ pub enum StorageError {
 
     #[error("pending error {0:?}")]
     PendingError(#[from] PendingError<CommitID>),
+
+    #[error("including duplicate keys within one commit")]
+    DuplicateKeysInOneCommit,
 }
 
 impl From<DecodeError> for StorageError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,9 +22,6 @@ pub enum StorageError {
 
     #[error("pending error {0:?}")]
     PendingError(#[from] PendingError<CommitID>),
-
-    #[error("including duplicate keys within one commit")]
-    DuplicateKeysInOneCommit,
 }
 
 impl From<DecodeError> for StorageError {

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -15,7 +15,6 @@ use crate::{
     errors::Result,
     lvmt::types::{compute_amt_node_id, AllocationKeyInfo, KEY_SLOT_SIZE},
     middlewares::table_schema::KeyValueSnapshotRead,
-    StorageError,
 };
 use crate::{
     lvmt::types::LvmtValue,
@@ -54,8 +53,9 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
 
         // Update version number
         for (key, value) in changes {
+            // skip the duplicated keys
             if !set_of_keys.insert(key.clone()) {
-                return Err(StorageError::DuplicateKeysInOneCommit);
+                continue;
             }
 
             let (allocation, version) = if let Some(old_value) = key_value_view.get(&key)? {

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -119,7 +119,7 @@ impl<'db> AllocationCacheDb<'db> {
         }
     }
 
-    fn set_cache(&mut self, amt_node_id: AmtNodeId, alloc_info: AllocationKeyInfo) {
+    fn set(&mut self, amt_node_id: AmtNodeId, alloc_info: AllocationKeyInfo) {
         self.cache.insert(amt_node_id, alloc_info);
     }
 }
@@ -143,7 +143,7 @@ fn allocate_version_slot(
             }
         };
 
-        allocation_cache_db.set_cache(amt_node_id, AllocationKeyInfo::new(next_index, key.into()));
+        allocation_cache_db.set(amt_node_id, AllocationKeyInfo::new(next_index, key.into()));
 
         return Ok(AllocatePosition {
             depth: depth as u8,

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -122,6 +122,10 @@ impl<'db> AllocationCacheDb<'db> {
     fn set(&mut self, amt_node_id: AmtNodeId, alloc_info: AllocationKeyInfo) {
         self.cache.insert(amt_node_id, alloc_info);
     }
+
+    fn into_changes(self) -> BTreeMap<AmtNodeId, AllocationKeyInfo> {
+        self.cache
+    }
 }
 
 fn allocate_version_slot(


### PR DESCRIPTION
## Summary
This PR fixes a bug in the slot allocation logic within the `commit` function of `LvmtStore`.

## Bug Description
The original logic processed each key in the `changes` parameter sequentially. If a key required a slot allocation, it would find the first slot not present in the `slot_alloc_view` (i.e., an immutable reference to the database) and allocate it to that key. Importantly, the database was not updated during this process. As a result, this approach may lead to multiple keys in the `changes` receiving the same slot allocation, which is incorrect.

## Solution
The updated logic introduces a cache to track slots occupied by keys that have already been processed in the changes parameter. It utilizes a new structure, `AllocationCacheDb`, to integrate the database and the cache. If a key requires a slot allocation, the logic finds the first slot not present in this new structure and allocates that slot to the key while also updating the cache accordingly.

Additionally, a related but separate change addresses the correctness of the updated logic, which relies on there being no duplicate keys; otherwise, it will allocate different slots to the same key. Since having no duplicate keys is a requirement, the implementation now skips any duplicate keys encountered in the input parameter `changes`.

## Conclusion
These modifications correct the slot allocation logic by ensuring that each key receives a unique slot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/16)
<!-- Reviewable:end -->
