### PR TITLE
Implement writing down to db for `LvmtStore`

### DIFF
--- a/src/backends/serde.rs
+++ b/src/backends/serde.rs
@@ -147,6 +147,10 @@ impl Decode for [H256; 4] {
     }
 }
 
+impl FixedLengthEncoded for H256 {
+    const LENGTH: usize = std::mem::size_of::<H256>();
+}
+
 #[macro_export]
 macro_rules! subkey_not_support {
     ($($t:ty),+) => {

--- a/src/lvmt/auth_changes.rs
+++ b/src/lvmt/auth_changes.rs
@@ -4,9 +4,11 @@ use blake2::Blake2s;
 use ethereum_types::H256;
 
 use crate::backends::serde::Encode;
+use crate::backends::serde::FixedLengthEncoded;
 use crate::backends::TableName;
 use crate::backends::TableSchema;
 use crate::lvmt::types::auth_changes::log2_ceil;
+use crate::middlewares::ChangeKey;
 
 use super::types::{
     auth_changes::{MAX_NODE_SIZE, MAX_NODE_SIZE_LOG},
@@ -19,8 +21,12 @@ pub struct AuthChangeTable;
 impl TableSchema for AuthChangeTable {
     const NAME: TableName = TableName::AuthNodeChange;
 
-    type Key = AuthChangeKey;
+    type Key = ChangeKey<H256, AuthChangeKey>;
     type Value = AuthChangeNode;
+}
+
+impl FixedLengthEncoded for H256 {
+    const LENGTH: usize = std::mem::size_of::<H256>();
 }
 
 const KEY_VALUE_CHANGE_FLAG: u8 = 0;

--- a/src/lvmt/auth_changes.rs
+++ b/src/lvmt/auth_changes.rs
@@ -3,12 +3,11 @@ use std::collections::BTreeMap;
 use blake2::Blake2s;
 use ethereum_types::H256;
 
-use crate::backends::serde::Encode;
-use crate::backends::TableName;
-use crate::backends::TableSchema;
-use crate::lvmt::types::auth_changes::log2_ceil;
-use crate::middlewares::ChangeKey;
-use crate::middlewares::CommitID;
+use crate::{
+    backends::{serde::Encode, TableName, TableSchema},
+    lvmt::types::auth_changes::log2_ceil,
+    middlewares::{ChangeKey, CommitID},
+};
 
 use super::types::{
     auth_changes::{MAX_NODE_SIZE, MAX_NODE_SIZE_LOG},

--- a/src/lvmt/auth_changes.rs
+++ b/src/lvmt/auth_changes.rs
@@ -4,11 +4,11 @@ use blake2::Blake2s;
 use ethereum_types::H256;
 
 use crate::backends::serde::Encode;
-use crate::backends::serde::FixedLengthEncoded;
 use crate::backends::TableName;
 use crate::backends::TableSchema;
 use crate::lvmt::types::auth_changes::log2_ceil;
 use crate::middlewares::ChangeKey;
+use crate::middlewares::CommitID;
 
 use super::types::{
     auth_changes::{MAX_NODE_SIZE, MAX_NODE_SIZE_LOG},
@@ -21,12 +21,8 @@ pub struct AuthChangeTable;
 impl TableSchema for AuthChangeTable {
     const NAME: TableName = TableName::AuthNodeChange;
 
-    type Key = ChangeKey<H256, AuthChangeKey>;
+    type Key = ChangeKey<CommitID, AuthChangeKey>;
     type Value = AuthChangeNode;
-}
-
-impl FixedLengthEncoded for H256 {
-    const LENGTH: usize = std::mem::size_of::<H256>();
 }
 
 const KEY_VALUE_CHANGE_FLAG: u8 = 0;

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -107,13 +107,22 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
             .into_iter()
             .map(|(k, v)| (k, Some(v)))
             .collect();
-        self.key_value_store
-            .add_to_pending_part(Some(old_commit), new_commit, key_value_updates)?;
+        self.key_value_store.add_to_pending_part(
+            Some(old_commit),
+            new_commit,
+            key_value_updates,
+        )?;
 
-        let slot_alloc_updates: BTreeMap<_, _> =
-            allocations.into_changes().into_iter().map(|(k, v)| (k, Some(v))).collect();
-        self.slot_alloc_store
-            .add_to_pending_part(Some(old_commit), new_commit, slot_alloc_updates)?;
+        let slot_alloc_updates: BTreeMap<_, _> = allocations
+            .into_changes()
+            .into_iter()
+            .map(|(k, v)| (k, Some(v)))
+            .collect();
+        self.slot_alloc_store.add_to_pending_part(
+            Some(old_commit),
+            new_commit,
+            slot_alloc_updates,
+        )?;
 
         let auth_change_bulk = auth_changes.into_iter().map(|(k, v)| (k, Some(v)));
         self.auth_changes

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
 use amt::AmtParams;
-use ethereum_types::H256;
 
 use super::{
     amt_change_manager::AmtChangeManager,
@@ -14,7 +13,7 @@ use crate::{
     backends::WriteSchemaTrait,
     errors::Result,
     lvmt::types::{compute_amt_node_id, AllocationKeyInfo, KEY_SLOT_SIZE},
-    middlewares::table_schema::KeyValueSnapshotRead,
+    middlewares::{table_schema::KeyValueSnapshotRead, CommitID},
     traits::KeyValueStoreBulksTrait,
 };
 use crate::{
@@ -36,8 +35,8 @@ const ALLOC_START_VERSION: u64 = 1;
 impl<'cache, 'db> LvmtStore<'cache, 'db> {
     fn commit(
         &mut self,
-        old_commit: H256,
-        new_commit: H256,
+        old_commit: CommitID,
+        new_commit: CommitID,
         changes: impl Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
         write_schema: &impl WriteSchemaTrait,
         pp: &AmtParams<PE>,

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -15,6 +15,7 @@ use crate::{
     errors::Result,
     lvmt::types::{compute_amt_node_id, AllocationKeyInfo, KEY_SLOT_SIZE},
     middlewares::table_schema::KeyValueSnapshotRead,
+    traits::KeyValueStoreBulksTrait,
 };
 use crate::{
     lvmt::types::LvmtValue,
@@ -34,7 +35,7 @@ const ALLOC_START_VERSION: u64 = 1;
 
 impl<'cache, 'db> LvmtStore<'cache, 'db> {
     fn commit(
-        &self,
+        &mut self,
         old_commit: H256,
         new_commit: H256,
         changes: impl Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
@@ -93,7 +94,31 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
             process_dump_items(hashes)
         };
 
-        // TODO: write down to db
+        // Write to the pending part of db.
+        // # Notes
+        // - Write to the history part is beyond the range of [`LvmtStore`].
+        // - The `auth_changes` in [`LvmtStore`] includes all commits, even if they are removed but not confirmed,
+        //   so consider `gc_commit` elsewhere.
+        let amt_node_updates: BTreeMap<_, _> =
+            amt_changes.into_iter().map(|(k, v)| (k, Some(v))).collect();
+        self.amt_node_store
+            .add_to_pending_part(Some(old_commit), new_commit, amt_node_updates)?;
+
+        let key_value_updates: BTreeMap<_, _> = key_value_changes
+            .into_iter()
+            .map(|(k, v)| (k, Some(v)))
+            .collect();
+        self.key_value_store
+            .add_to_pending_part(Some(old_commit), new_commit, key_value_updates)?;
+
+        let slot_alloc_updates: BTreeMap<_, _> =
+            allocations.into_changes().into_iter().map(|(k, v)| (k, Some(v))).collect();
+        self.slot_alloc_store
+            .add_to_pending_part(Some(old_commit), new_commit, slot_alloc_updates)?;
+
+        let auth_change_bulk = auth_changes.into_iter().map(|(k, v)| (k, Some(v)));
+        self.auth_changes
+            .commit(new_commit, auth_change_bulk, write_schema)?;
 
         Ok(())
     }

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -94,10 +94,9 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
         };
 
         // Write to the pending part of db.
-        // # Notes
-        // - Write to the history part is beyond the range of [`LvmtStore`].
-        // - The `auth_changes` in [`LvmtStore`] includes all commits, even if they are removed but not confirmed,
-        //   so consider `gc_commit` elsewhere.
+        // TODO: Write to the history part is beyond the range of LvmtStore.
+        // TODO: LvmtStore.auth_changes includes all commits, even if they are removed but not confirmed,
+        //       so consider gc_commit elsewhere.
         let amt_node_updates: BTreeMap<_, _> =
             amt_changes.into_iter().map(|(k, v)| (k, Some(v))).collect();
         self.amt_node_store


### PR DESCRIPTION
This PR implements writing to the database for `LvmtStore` within the `commit` function.

- For `amt_node_store`, `key_value_store`, and `slot_alloc_store`, the corresponding updates are written to their pending parts. Writing to the history part is beyond the scope of `LvmtStore`.
- The `auth_changes` is a `KeyValueStoreBulks`, which typically only supports appending. Therefore, all commits, even if they are removed but not confirmed, are written to `auth_changes`, so consider `gc_commit` elsewhere. To enable committing `auth_changes`, the `Key` type of `AuthChangeTable` should be changed to `ChangeKey` to allow the `auth_changes` to satisfy the `KeyValueStoreBulksTrait`.

Additionally, references to `CommitID` have been updated to use the type alias, retaining `H256` for other purposes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/17)
<!-- Reviewable:end -->
