### PR TITLE
Support deletions in `LvmtStore` by using `Option<Box<[u8]>>` for `changes` and `LvmtValue.value`

### DIFF
--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -51,7 +51,7 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
         &mut self,
         old_commit: Option<CommitID>,
         new_commit: CommitID,
-        changes: impl Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
+        changes: impl Iterator<Item = (Box<[u8]>, Option<Box<[u8]>>)>,
         write_schema: &impl WriteSchemaTrait,
         pp: &AmtParams<PE>,
     ) -> Result<()> {

--- a/src/lvmt/types/lvmt_value.rs
+++ b/src/lvmt/types/lvmt_value.rs
@@ -8,32 +8,48 @@ use super::allocation::AllocatePosition;
 pub struct LvmtValue {
     pub(in crate::lvmt) allocation: AllocatePosition,
     pub(in crate::lvmt) version: u64,
-    pub(in crate::lvmt) value: Box<[u8]>,
+    pub(in crate::lvmt) value: Option<Box<[u8]>>,
 }
 
 impl Encode for LvmtValue {
     fn encode(&self) -> std::borrow::Cow<[u8]> {
         let mut encoded: Vec<u8> = self.allocation.encode().into_owned();
         encoded.extend(&self.version.to_le_bytes()[0..5]);
-        encoded.extend(&*self.value);
+
+        // Add a flag to indicate whether the value is present
+        let value_present = self.value.is_some() as u8;
+        encoded.push(value_present);
+        if let Some(value) = &self.value {
+            encoded.extend(&**value);
+        }
+
         Cow::Owned(encoded)
     }
 }
 
 impl Decode for LvmtValue {
     fn decode(input: &[u8]) -> DecResult<Cow<Self>> {
-        if input.len() < 6 {
+        if input.len() < 7 {
             return Err(DecodeError::TooShortHeader);
         }
-        let (header, body) = input.split_at(6);
-        let (allocation_raw, version_raw) = header.split_at(1);
+
+        let (header, body) = input.split_at(7);
+        let (allocation_raw, version_raw_with_flag) = header.split_at(1);
+        let (version_raw, flag) = version_raw_with_flag.split_at(5);
+
         let allocation = AllocatePosition::decode(allocation_raw)?.into_owned();
 
         let mut version_bytes = [0u8; 8];
         version_bytes[0..5].copy_from_slice(version_raw);
 
         let version = u64::from_le_bytes(version_bytes);
-        let value = body.to_vec().into_boxed_slice();
+
+        let value_present = flag[0] != 0;
+        let value = if value_present {
+            Some(body.to_vec().into_boxed_slice())
+        } else {
+            None
+        };
 
         Ok(Cow::Owned(Self {
             allocation,

--- a/src/lvmt/types/mod.rs
+++ b/src/lvmt/types/mod.rs
@@ -31,8 +31,11 @@ pub mod test_utils {
         prop_oneof![0u64..10000, 0u64..(1 << 40)]
     }
 
-    pub fn value_strategy() -> impl Strategy<Value = Box<[u8]>> {
-        vec(0u8..=255, 0..128).prop_map(|x| x.into_boxed_slice())
+    pub fn value_strategy() -> impl Strategy<Value = Option<Box<[u8]>>> {
+        prop_oneof![
+            vec(0u8..=255, 0..128).prop_map(|x| Some(x.into_boxed_slice())),
+            Just(None),
+        ]
     }
 
     pub fn bytes32_strategy() -> impl Strategy<Value = H256> {


### PR DESCRIPTION
This PR introduces support for deletions in the `LvmtStore` by replacing the `Box<[u8]>` type with `Option<Box<[u8]>>` in both the `changes` parameter of the `commit` function and the `value` field of the `LvmtValue` struct.

Additionally, unit tests for `LvmtValue` now include cases where the `value` is `None`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/20)
<!-- Reviewable:end -->
