### PR TITLE
Adapting to Conflux storage interface: Implement `get_state` method for `LvmtStore`

### DIFF
--- a/src/lvmt/mod.rs
+++ b/src/lvmt/mod.rs
@@ -2,6 +2,7 @@ mod amt_change_manager;
 mod auth_changes;
 pub mod crypto;
 mod example;
+mod snapshot;
 mod storage;
 pub mod table_schema;
 #[cfg(test)]

--- a/src/lvmt/snapshot.rs
+++ b/src/lvmt/snapshot.rs
@@ -1,0 +1,21 @@
+use crate::{
+    errors::Result,
+    middlewares::{table_schema::KeyValueSnapshotRead, CommitID},
+    traits::KeyValueStoreManager,
+};
+
+use super::{storage::LvmtStore, table_schema::FlatKeyValue};
+
+pub struct LvmtSnapshot<'db> {
+    key_value_view: Box<KeyValueSnapshotRead<'db, FlatKeyValue>>,
+}
+
+impl<'cache, 'db> LvmtStore<'cache, 'db> {
+    fn get_state(&self, commit: CommitID) -> Result<LvmtSnapshot> {
+        let key_value_view = self.get_key_value_store().get_versioned_store(&commit)?;
+
+        Ok(LvmtSnapshot {
+            key_value_view: Box::new(key_value_view),
+        })
+    }
+}

--- a/src/lvmt/snapshot.rs
+++ b/src/lvmt/snapshot.rs
@@ -1,6 +1,9 @@
 use crate::{
     errors::Result,
-    middlewares::{table_schema::KeyValueSnapshotRead, CommitID},
+    middlewares::{
+        table_schema::{KeyValueSnapshotRead, VersionedKeyValueSchema},
+        CommitID,
+    },
     traits::KeyValueStoreManager,
 };
 
@@ -11,11 +14,20 @@ pub struct LvmtSnapshot<'db> {
 }
 
 impl<'cache, 'db> LvmtStore<'cache, 'db> {
-    fn get_state(&self, commit: CommitID) -> Result<LvmtSnapshot> {
+    pub fn get_state(&self, commit: CommitID) -> Result<LvmtSnapshot> {
         let key_value_view = self.get_key_value_store().get_versioned_store(&commit)?;
 
         Ok(LvmtSnapshot {
             key_value_view: Box::new(key_value_view),
         })
+    }
+}
+
+impl<'db> LvmtSnapshot<'db> {
+    pub fn get(
+        &self,
+        key: &<FlatKeyValue as VersionedKeyValueSchema>::Key,
+    ) -> Result<Option<<FlatKeyValue as VersionedKeyValueSchema>::Value>> {
+        self.key_value_view.get(key)
     }
 }

--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -203,14 +203,17 @@ fn allocate_version_slot(
     }
 }
 
-#[cfg(test)]
 impl<'cache, 'db> LvmtStore<'cache, 'db> {
     pub fn get_key_value_store(&self) -> &VersionedStore<'cache, 'db, FlatKeyValue> {
         &self.key_value_store
     }
+
+    #[cfg(test)]
     pub fn get_amt_node_store(&self) -> &VersionedStore<'cache, 'db, AmtNodes> {
         &self.amt_node_store
     }
+
+    #[cfg(test)]
     pub fn get_slot_alloc_store(&self) -> &VersionedStore<'cache, 'db, SlotAllocations> {
         &self.slot_alloc_store
     }


### PR DESCRIPTION
This PR introduces a new method `get_state` for the `LvmtStore` struct, allowing retrieval of a `LvmtSnapshot` for a specific `CommitID`. The `LvmtSnapshot` provides a snapshot of the key-value store at the given commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/22)
<!-- Reviewable:end -->
