### PR TITLE
Refactor: reduce snapshot allocation overhead by reference sharing

### DIFF
--- a/src/middlewares/versioned_flat_key_value/pending_part/versioned_map.rs
+++ b/src/middlewares/versioned_flat_key_value/pending_part/versioned_map.rs
@@ -195,6 +195,10 @@ impl<S: PendingKeyValueSchema> VersionedMap<S> {
         }
     }
 
+    pub fn contains_commit_id(&self, commit_id: &S::CommitId) -> bool {
+        self.tree.contains_commit_id(commit_id)
+    }
+
     pub fn get_versioned_store(&self, commit_id: S::CommitId) -> PendResult<KeyValueMap<S>, S> {
         // let query node to be self.current
         let mut guard = self.current.write();

--- a/src/middlewares/versioned_flat_key_value/tests.rs
+++ b/src/middlewares/versioned_flat_key_value/tests.rs
@@ -167,9 +167,9 @@ struct MockNode<T: VersionedKeyValueSchema> {
 impl<T: VersionedKeyValueSchema> KeyValueStoreManager<T::Key, T::Value, CommitID>
     for MockVersionedStore<T>
 {
-    type Store = MockOneStore<T::Key, T::Value>;
+    type Store<'a> = MockOneStore<T::Key, T::Value> where Self: 'a;
 
-    fn get_versioned_store(&self, commit: &CommitID) -> Result<Self::Store> {
+    fn get_versioned_store<'a>(&'a self, commit: &CommitID) -> Result<Self::Store<'a>> {
         if let Some(pending_res) = self.pending.tree.get(commit) {
             Ok(MockOneStore::from_mock_map(&pending_res.store))
         } else if let Some((_, history_res)) = self.history.get(commit) {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -25,10 +25,12 @@ where
     V: 'static,
     C: 'static,
 {
-    type Store: KeyValueStoreRead<K, V>;
+    type Store<'a>: KeyValueStoreRead<K, V>
+    where
+        Self: 'a;
 
     /// Get the key value store after the commit of given id
-    fn get_versioned_store(&self, commit: &C) -> Result<Self::Store>;
+    fn get_versioned_store<'a>(&'a self, commit: &C) -> Result<Self::Store<'a>>;
 
     /// Start from the given commit, and iter changes backforward
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
Previously, `SnapshotView` maintained a complete copy of the current map in the pending part, resulting in significant allocation and deallocation overhead.

This PR replaces the direct copy with reference sharing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/24)
<!-- Reviewable:end -->
