### PR TITLE
Refactor: replace unnecessary `BTreeMap` with `HashMap`

### DIFF
--- a/src/lvmt/storage.rs
+++ b/src/lvmt/storage.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use amt::AmtParams;
 
@@ -118,19 +118,19 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
         // TODO: Write to the history part is beyond the range of LvmtStore.
         // TODO: LvmtStore.auth_changes includes all commits, even if they are removed but not confirmed,
         //       so consider gc_commit elsewhere.
-        let amt_node_updates: BTreeMap<_, _> =
+        let amt_node_updates: HashMap<_, _> =
             amt_changes.into_iter().map(|(k, v)| (k, Some(v))).collect();
         self.amt_node_store
             .add_to_pending_part(old_commit, new_commit, amt_node_updates)?;
 
-        let key_value_updates: BTreeMap<_, _> = key_value_changes
+        let key_value_updates: HashMap<_, _> = key_value_changes
             .into_iter()
             .map(|(k, v)| (k, Some(v)))
             .collect();
         self.key_value_store
             .add_to_pending_part(old_commit, new_commit, key_value_updates)?;
 
-        let slot_alloc_updates: BTreeMap<_, _> = allocations
+        let slot_alloc_updates: HashMap<_, _> = allocations
             .into_changes()
             .into_iter()
             .map(|(k, v)| (k, Some(v)))
@@ -148,7 +148,7 @@ impl<'cache, 'db> LvmtStore<'cache, 'db> {
 
 struct AllocationCacheDb<'db> {
     db: &'db KeyValueSnapshotRead<'db, SlotAllocations>,
-    cache: BTreeMap<AmtNodeId, AllocationKeyInfo>,
+    cache: HashMap<AmtNodeId, AllocationKeyInfo>,
 }
 
 impl<'db> AllocationCacheDb<'db> {
@@ -170,7 +170,7 @@ impl<'db> AllocationCacheDb<'db> {
         self.cache.insert(amt_node_id, alloc_info);
     }
 
-    fn into_changes(self) -> BTreeMap<AmtNodeId, AllocationKeyInfo> {
+    fn into_changes(self) -> HashMap<AmtNodeId, AllocationKeyInfo> {
         self.cache
     }
 }

--- a/src/lvmt/tests.rs
+++ b/src/lvmt/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use once_cell::sync::Lazy;
 use rand_chacha::ChaChaRng;
@@ -28,7 +28,7 @@ fn u64_to_boxed_u8(value: u64) -> Box<[u8]> {
 }
 
 fn get_changes_from_updates(
-    updates: BTreeMap<u64, Option<u64>>,
+    updates: HashMap<u64, Option<u64>>,
 ) -> impl Iterator<Item = (Box<[u8]>, Option<Box<[u8]>>)> {
     updates
         .into_iter()

--- a/src/middlewares/versioned_flat_key_value/mod.rs
+++ b/src/middlewares/versioned_flat_key_value/mod.rs
@@ -6,7 +6,7 @@ pub mod table_schema;
 mod tests;
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub use pending_part::PendingError;
@@ -77,7 +77,7 @@ impl<'cache, 'db, T: VersionedKeyValueSchema> VersionedStore<'cache, 'db, T> {
         &mut self,
         parent_commit: Option<CommitID>,
         commit: CommitID,
-        updates: BTreeMap<T::Key, Option<T::Value>>,
+        updates: HashMap<T::Key, Option<T::Value>>,
     ) -> Result<()> {
         if self.commit_id_table.get(&commit)?.is_some() {
             return Err(StorageError::CommitIdAlreadyExistsInHistory);
@@ -164,7 +164,7 @@ pub fn confirmed_pending_to_history<D: DatabaseTrait, T: VersionedKeyValueSchema
 pub fn confirm_maps_to_history<D: DatabaseTrait, T: VersionedKeyValueSchema>(
     db: &D,
     to_confirm_start_height: usize,
-    to_confirm_maps: Vec<BTreeMap<T::Key, impl Into<Option<T::Value>>>>,
+    to_confirm_maps: Vec<HashMap<T::Key, impl Into<Option<T::Value>>>>,
     write_schema: &D::WriteSchema,
 ) -> Result<()> {
     let history_index_table = db.view::<HistoryIndicesTable<T>>()?;

--- a/src/middlewares/versioned_flat_key_value/pending_part/current_map.rs
+++ b/src/middlewares/versioned_flat_key_value/pending_part/current_map.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::Deref};
+use std::{collections::HashMap, ops::Deref};
 
 use super::{
     pending_schema::{ApplyMap, ApplyRecord, PendingKeyValueSchema},
@@ -6,12 +6,12 @@ use super::{
 };
 
 pub(super) struct CurrentMap<S: PendingKeyValueSchema> {
-    map: BTreeMap<S::Key, ApplyRecord<S>>,
+    map: HashMap<S::Key, ApplyRecord<S>>,
     commit_id: S::CommitId,
 }
 
 impl<S: PendingKeyValueSchema> Deref for CurrentMap<S> {
-    type Target = BTreeMap<S::Key, ApplyRecord<S>>;
+    type Target = HashMap<S::Key, ApplyRecord<S>>;
 
     fn deref(&self) -> &Self::Target {
         &self.map
@@ -21,7 +21,7 @@ impl<S: PendingKeyValueSchema> Deref for CurrentMap<S> {
 impl<S: PendingKeyValueSchema> CurrentMap<S> {
     pub fn new(commit_id: S::CommitId) -> Self {
         Self {
-            map: BTreeMap::new(),
+            map: HashMap::new(),
             commit_id,
         }
     }
@@ -34,7 +34,7 @@ impl<S: PendingKeyValueSchema> CurrentMap<S> {
         self.commit_id = commit_id;
     }
 
-    pub fn rollback(&mut self, rollbacks: BTreeMap<S::Key, Option<ApplyRecord<S>>>) {
+    pub fn rollback(&mut self, rollbacks: HashMap<S::Key, Option<ApplyRecord<S>>>) {
         for (key, to_rollback) in rollbacks.into_iter() {
             match to_rollback {
                 None => {

--- a/src/middlewares/versioned_flat_key_value/pending_part/pending_schema.rs
+++ b/src/middlewares/versioned_flat_key_value/pending_part/pending_schema.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use crate::middlewares::versioned_flat_key_value::table_schema::VersionedKeyValueSchema;
 use crate::types::ValueEntry;
@@ -41,10 +41,10 @@ impl<S: PendingKeyValueSchema> ConfirmedPathInfo<S> {
     }
 }
 
-pub type KeyValueMap<S> = BTreeMap<Key<S>, ValueEntry<Value<S>>>;
-pub type RecoverMap<S> = BTreeMap<Key<S>, RecoverRecord<S>>;
-pub type ApplyMap<S> = BTreeMap<Key<S>, ApplyRecord<S>>;
-pub type LastCommitIdMap<S> = BTreeMap<Key<S>, Option<CommitId<S>>>;
+pub type KeyValueMap<S> = HashMap<Key<S>, ValueEntry<Value<S>>>;
+pub type RecoverMap<S> = HashMap<Key<S>, RecoverRecord<S>>;
+pub type ApplyMap<S> = HashMap<Key<S>, ApplyRecord<S>>;
+pub type LastCommitIdMap<S> = HashMap<Key<S>, Option<CommitId<S>>>;
 
 pub type CommitIdVec<S> = Vec<CommitId<S>>;
 pub type Result<T, S> = std::result::Result<T, PendingError<CommitId<S>>>;

--- a/src/middlewares/versioned_flat_key_value/pending_part/tree/checkout.rs
+++ b/src/middlewares/versioned_flat_key_value/pending_part/tree/checkout.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use crate::middlewares::versioned_flat_key_value::pending_part::{
     current_map::CurrentMap,
@@ -61,7 +61,7 @@ impl<S: PendingKeyValueSchema> Tree<S> {
         target_commit_id: S::CommitId,
     ) -> PendResult<ApplyMap<S>, S> {
         let mut target_node = self.get_node_by_commit_id(target_commit_id)?;
-        let mut commits_rev = BTreeMap::new();
+        let mut commits_rev = HashMap::new();
         target_node.export_commit_data::<false>(&mut commits_rev);
         while let Some(parent_slab_index) = target_node.get_parent() {
             target_node = self.get_node_by_slab_index(parent_slab_index);
@@ -76,11 +76,11 @@ impl<S: PendingKeyValueSchema> Tree<S> {
         &self,
         current_commit_id: S::CommitId,
         target_commit_id: S::CommitId,
-    ) -> PendResult<(BTreeMap<S::Key, Option<ApplyRecord<S>>>, ApplyMap<S>), S> {
+    ) -> PendResult<(HashMap<S::Key, Option<ApplyRecord<S>>>, ApplyMap<S>), S> {
         let mut current_node = self.get_node_by_commit_id(current_commit_id)?;
         let mut target_node = self.get_node_by_commit_id(target_commit_id)?;
-        let mut rollbacks = BTreeMap::new();
-        let mut commits_rev = BTreeMap::new();
+        let mut rollbacks = HashMap::new();
+        let mut commits_rev = HashMap::new();
 
         while current_node.get_height() > target_node.get_height() {
             current_node.export_rollback_data::<true>(&mut rollbacks);
@@ -100,7 +100,7 @@ impl<S: PendingKeyValueSchema> Tree<S> {
             target_node = self.get_parent_node(target_node).unwrap();
         }
 
-        let mut rollbacks_with_value = BTreeMap::new();
+        let mut rollbacks_with_value = HashMap::new();
         for (key, old_commit_id) in rollbacks.into_iter() {
             let actual_old_commit_id = if let Some(ref old_commit_id) = old_commit_id {
                 // check rollbacks' old_commit_id because TreeNodes are deleted in a lazy way with respect to TreeNodes.modifications

--- a/src/middlewares/versioned_flat_key_value/pending_part/versioned_map.rs
+++ b/src/middlewares/versioned_flat_key_value/pending_part/versioned_map.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use crate::traits::{IsCompleted, NeedNext};
 use crate::types::ValueEntry;
@@ -99,7 +99,7 @@ impl<S: PendingKeyValueSchema> VersionedMap<S> {
 
         // add node to tree
         let current = guard.as_ref().unwrap();
-        let mut modifications = BTreeMap::new();
+        let mut modifications = HashMap::new();
         for (key, value) in updates {
             let last_commit_id = current.get(&key).map(|s| s.commit_id);
             modifications.insert(
@@ -266,7 +266,7 @@ mod tests {
             } else {
                 Some(rng.gen_range(1..i))
             };
-            let mut updates = BTreeMap::new();
+            let mut updates = HashMap::new();
             for _ in 0..5 {
                 let (key, value) = random_key_value(rng);
                 updates.insert(key, value);
@@ -333,15 +333,15 @@ mod tests {
         let mut forward_only_tree = Tree::<TestPendingConfig>::new(None, 0);
         let mut versioned_map = VersionedMap::<TestPendingConfig>::new(None, 0);
 
-        forward_only_tree.add_root(0, BTreeMap::new()).unwrap();
-        versioned_map.add_node(BTreeMap::new(), 0, None).unwrap();
+        forward_only_tree.add_root(0, HashMap::new()).unwrap();
+        versioned_map.add_node(HashMap::new(), 0, None).unwrap();
 
         assert_eq!(
-            forward_only_tree.add_root(1, BTreeMap::new()),
+            forward_only_tree.add_root(1, HashMap::new()),
             Err(PendingError::MultipleRootsNotAllowed)
         );
         assert_eq!(
-            versioned_map.add_node(BTreeMap::new(), 1, None),
+            versioned_map.add_node(HashMap::new(), 1, None),
             Err(PendingError::MultipleRootsNotAllowed)
         );
     }
@@ -352,11 +352,11 @@ mod tests {
         let mut versioned_map = VersionedMap::<TestPendingConfig>::new(None, 0);
 
         assert_eq!(
-            forward_only_tree.add_non_root_node(1, 0, BTreeMap::new()),
+            forward_only_tree.add_non_root_node(1, 0, HashMap::new()),
             Err(PendingError::CommitIDNotFound(0))
         );
         assert_eq!(
-            versioned_map.add_node(BTreeMap::new(), 1, Some(0)),
+            versioned_map.add_node(HashMap::new(), 1, Some(0)),
             Err(PendingError::CommitIDNotFound(0))
         );
     }
@@ -366,15 +366,15 @@ mod tests {
         let mut forward_only_tree = Tree::<TestPendingConfig>::new(None, 0);
         let mut versioned_map = VersionedMap::<TestPendingConfig>::new(None, 0);
 
-        forward_only_tree.add_root(0, BTreeMap::new()).unwrap();
-        versioned_map.add_node(BTreeMap::new(), 0, None).unwrap();
+        forward_only_tree.add_root(0, HashMap::new()).unwrap();
+        versioned_map.add_node(HashMap::new(), 0, None).unwrap();
 
         assert_eq!(
-            forward_only_tree.add_non_root_node(0, 0, BTreeMap::new()),
+            forward_only_tree.add_non_root_node(0, 0, HashMap::new()),
             Err(PendingError::CommitIdAlreadyExists(0))
         );
         assert_eq!(
-            versioned_map.add_node(BTreeMap::new(), 0, Some(0)),
+            versioned_map.add_node(HashMap::new(), 0, Some(0)),
             Err(PendingError::CommitIdAlreadyExists(0))
         );
     }

--- a/src/middlewares/versioned_flat_key_value/tests.rs
+++ b/src/middlewares/versioned_flat_key_value/tests.rs
@@ -272,7 +272,7 @@ impl<T: VersionedKeyValueSchema> KeyValueStoreManager<T::Key, T::Value, CommitID
 
 fn update_last_store_to_store<T: VersionedKeyValueSchema>(
     last_store: &MockStore<T>,
-    updates: BTreeMap<T::Key, Option<T::Value>>,
+    updates: HashMap<T::Key, Option<T::Value>>,
 ) -> MockStore<T> {
     let mut store: BTreeMap<_, _> = last_store
         .iter()
@@ -327,7 +327,7 @@ impl<T: Eq + std::hash::Hash + Clone> UniqueVec<T> {
 impl<T: VersionedKeyValueSchema> MockVersionedStore<T> {
     pub fn build(
         history_cids: UniqueVec<CommitID>,
-        history_updates: Vec<BTreeMap<T::Key, Option<T::Value>>>,
+        history_updates: Vec<HashMap<T::Key, Option<T::Value>>>,
     ) -> Self {
         assert_eq!(history_cids.len(), history_updates.len());
         let mut history: HashMap<_, _> = Default::default();
@@ -465,7 +465,7 @@ impl<T: VersionedKeyValueSchema> MockVersionedStore<T> {
         &mut self,
         parent_commit: Option<CommitID>,
         commit: CommitID,
-        updates: BTreeMap<T::Key, Option<T::Value>>,
+        updates: HashMap<T::Key, Option<T::Value>>,
     ) -> Result<()> {
         if self.history.contains_key(&commit) {
             return Err(StorageError::CommitIdAlreadyExistsInHistory);
@@ -649,9 +649,9 @@ pub fn gen_updates(
     num_gen_new_keys: usize,
     num_gen_previous_keys: usize,
     all_keys: &mut BTreeSet<u64>,
-) -> BTreeMap<u64, Option<u64>> {
+) -> HashMap<u64, Option<u64>> {
     // gen previous keys (i.e., replace), allow redundant keys and adopt the newest value for the same key
-    let mut updates: BTreeMap<_, _> = if !previous_keys.is_empty() {
+    let mut updates: HashMap<_, _> = if !previous_keys.is_empty() {
         let previous_keys_vec: Vec<_> = previous_keys.iter().cloned().collect();
         (0..num_gen_previous_keys)
             .map(|_| {
@@ -694,7 +694,7 @@ fn gen_init<D: DatabaseTrait>(
     write_schema: &D::WriteSchema,
 ) -> (
     UniqueVec<CommitID>,
-    Vec<BTreeMap<u64, Option<u64>>>,
+    Vec<HashMap<u64, Option<u64>>>,
     VersionedMap<PendingKeyValueConfig<TestSchema, CommitID>>,
 ) {
     let mut history_cids = UniqueVec::new();


### PR DESCRIPTION
Changed the `modifications` in `TreeNode` from `BTreeMap` to `HashMap` to significantly improve performance of `get_modified_value` operations.

This PR replaces all `BTreeMap` instances with `HashMap` where the ordering features of `BTreeMap` aren't being utilized. If specific use cases requiring `BTreeMap` functionality are identified in the future, those can be addressed separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/cfx-storage2/27)
<!-- Reviewable:end -->
